### PR TITLE
feat: redesign dashboard with modal-based ux

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,87 +3,310 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>QA Dashboard</title>
+    <title>QA Manager</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header>
-      <h1>QA Dashboard</h1>
-    </header>
-
-    <main>
-      <!-- DASHBOARD -->
-      <section id="secDashboard">
-        <div class="topbar">
-          <h2>Lojas</h2>
-          <button id="btnNovaLoja">+ Nova Loja</button>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <div class="brand-icon" aria-hidden="true">🧪</div>
+          <div class="brand-text">
+            <h1>QA Manager</h1>
+            <p>Orquestre lojas, ambientes e execuções de QA em um só lugar.</p>
+          </div>
         </div>
-        <div id="dashboardStores" class="grid"></div>
-      </section>
-
-      <!-- LOJA DETALHE -->
-      <section id="secLoja" style="display: none">
-        <div class="topbar">
-          <button id="btnVoltarDashboard">← Voltar</button>
-          <h2 id="lojaTitulo"></h2>
+        <div class="header-actions">
+          <button id="btnNovaLoja" class="primary">+ Nova Loja</button>
         </div>
+      </header>
 
-        <div class="card">
-          <h3>Gerenciar Loja</h3>
-          <button id="btnEditarLoja">Editar Nome/Site</button>
-          <button id="btnExcluirLoja">Excluir Loja</button>
+      <main>
+        <section id="secDashboard" class="view is-visible">
+          <div class="section-heading">
+            <div>
+              <h2>Painel de Lojas</h2>
+              <p class="muted">
+                Acompanhe rapidamente quais lojas fazem parte do programa de QA e
+                acesse seus detalhes.
+              </p>
+            </div>
+          </div>
+          <div id="dashboardStores" class="grid"></div>
+        </section>
+
+        <section id="secLoja" class="view">
+          <div class="topbar">
+            <button id="btnVoltarDashboard" class="ghost">← Voltar</button>
+            <h2 id="lojaTitulo"></h2>
+          </div>
+
+          <div class="card card--overview">
+            <div class="card-header">
+              <div>
+                <p class="card-subtitle">Resumo da loja</p>
+              </div>
+              <div class="card-actions">
+                <button id="btnEditarLoja" class="ghost">Editar loja</button>
+                <button id="btnExcluirLoja" class="ghost danger">
+                  Excluir loja
+                </button>
+              </div>
+            </div>
+            <p id="lojaDescricao" class="muted"></p>
+            <div class="info-grid">
+              <div>
+                <span class="label">Site oficial</span>
+                <a
+                  id="lojaSite"
+                  class="link"
+                  href="#"
+                  target="_blank"
+                  rel="noopener"
+                ></a>
+              </div>
+              <div>
+                <span class="label">Total de cenários</span>
+                <strong id="lojaTotalCenarios">0</strong>
+              </div>
+              <div>
+                <span class="label">Ambientes ativos</span>
+                <strong id="lojaTotalAmbientes">0</strong>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3>Cadastrar cenário</h3>
+            </div>
+            <form id="scenarioForm" class="grid-form">
+              <div class="field">
+                <label for="scenarioTitle">Título</label>
+                <input type="text" id="scenarioTitle" required />
+              </div>
+              <div class="field">
+                <label for="scenarioCategory">Categoria</label>
+                <input type="text" id="scenarioCategory" required />
+              </div>
+              <div class="field">
+                <label for="scenarioAutomation">Automação</label>
+                <select id="scenarioAutomation">
+                  <option value="Automatizado">Automatizado</option>
+                  <option value="Não Automatizado">Não Automatizado</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="scenarioCluster">Cluster</label>
+                <select id="scenarioCluster">
+                  <option value="Desktop">Desktop</option>
+                  <option value="Mobile">Mobile</option>
+                  <option value="Ambos">Ambos</option>
+                </select>
+              </div>
+              <div class="field field--wide">
+                <label for="scenarioObs">Observações</label>
+                <textarea
+                  id="scenarioObs"
+                  rows="2"
+                  placeholder="Informações adicionais, links, pré-condições..."
+                ></textarea>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="primary">Adicionar cenário</button>
+              </div>
+            </form>
+
+            <table id="cenariosTabela"></table>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3>Ambientes</h3>
+              <button id="btnNovoAmbiente" class="primary">
+                + Criar ambiente
+              </button>
+            </div>
+            <p class="muted">
+              Crie ambientes de execução para acompanhar o progresso dos
+              cenários desta loja.
+            </p>
+            <div id="ambientesList" class="grid"></div>
+          </div>
+        </section>
+
+        <section id="secAmbiente" class="view">
+          <div class="topbar">
+            <button id="btnVoltarLoja" class="ghost">← Voltar</button>
+            <h2 id="ambienteTitulo"></h2>
+          </div>
+
+          <div class="card" id="ambienteResumo">
+            <div class="info-grid">
+              <div>
+                <span class="label">Loja</span>
+                <strong id="ambienteLoja">-</strong>
+              </div>
+              <div>
+                <span class="label">Tipo</span>
+                <strong id="ambienteKind">-</strong>
+              </div>
+              <div>
+                <span class="label">Identificador</span>
+                <strong id="ambienteIdentifier">-</strong>
+              </div>
+              <div>
+                <span class="label">Tipo de teste</span>
+                <strong id="ambienteTestType">-</strong>
+              </div>
+              <div>
+                <span class="label">Cenários</span>
+                <strong id="ambienteTotalCenarios">0</strong>
+              </div>
+            </div>
+            <p id="ambienteNotes" class="muted"></p>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3>Execução dos cenários</h3>
+            </div>
+            <ul id="cenariosExecucao" class="scenario-list"></ul>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <small>QA Manager · Integração com Firebase Firestore</small>
+      </footer>
+    </div>
+
+    <!-- Modal Nova/Editar Loja -->
+    <div class="modal" id="modalStore" role="dialog" aria-hidden="true">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 id="storeFormTitle">Nova loja</h3>
+          <button type="button" class="icon-button" data-modal-close>
+            ×
+          </button>
         </div>
-
-        <div class="card">
-          <h3>Cenários</h3>
-          <form id="scenarioForm" class="grid-form">
+        <form id="storeForm" class="modal-body">
+          <div class="field">
+            <label for="storeName">Nome</label>
+            <input id="storeName" name="storeName" type="text" required />
+          </div>
+          <div class="field">
+            <label for="storeSite">Site</label>
             <input
+              id="storeSite"
+              name="storeSite"
+              type="url"
+              placeholder="https://exemplo.com"
+            />
+          </div>
+          <div class="field">
+            <label for="storeDescription">Descrição</label>
+            <textarea
+              id="storeDescription"
+              name="storeDescription"
+              rows="3"
+              placeholder="Breve resumo sobre a loja ou o produto"
+            ></textarea>
+          </div>
+          <div class="modal-actions">
+            <button type="button" class="ghost" data-modal-close>
+              Cancelar
+            </button>
+            <button type="submit" id="storeFormSubmit" class="primary">
+              Salvar loja
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Modal Ambiente -->
+    <div
+      class="modal"
+      id="modalEnvironment"
+      role="dialog"
+      aria-hidden="true"
+    >
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Novo ambiente</h3>
+          <button type="button" class="icon-button" data-modal-close>
+            ×
+          </button>
+        </div>
+        <form id="environmentForm" class="modal-body">
+          <p class="muted">Loja selecionada: <span id="environmentStoreName"></span></p>
+          <div class="field">
+            <label for="environmentKind">Tipo de ambiente</label>
+            <input
+              id="environmentKind"
+              name="environmentKind"
               type="text"
-              id="scenarioTitle"
-              placeholder="Título"
+              placeholder="Ex.: WS, TM, App..."
               required
             />
+          </div>
+          <div class="field">
+            <label for="environmentTestType">Tipo de teste</label>
+            <select id="environmentTestType" name="environmentTestType">
+              <option value="Regressivo">Regressivo</option>
+              <option value="Smoke">Smoke</option>
+              <option value="Exploratório">Exploratório</option>
+              <option value="Performance">Performance</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="environmentIdentifier">Identificador</label>
             <input
+              id="environmentIdentifier"
+              name="environmentIdentifier"
               type="text"
-              id="scenarioCategory"
-              placeholder="Categoria"
+              placeholder="ex.: ws-qa"
               required
             />
-            <select id="scenarioAutomation">
-              <option value="Automatizado">Automatizado</option>
-              <option value="Não Automatizado">Não Automatizado</option>
-            </select>
-            <select id="scenarioCluster">
-              <option value="Desktop">Desktop</option>
-              <option value="Mobile">Mobile</option>
-              <option value="Ambos">Ambos</option>
-            </select>
-            <input type="text" id="scenarioObs" placeholder="Obs" />
-            <button type="submit">Adicionar</button>
-          </form>
-          <table id="cenariosTabela"></table>
-        </div>
+          </div>
+          <div class="field">
+            <label for="environmentNotes">Observações</label>
+            <textarea
+              id="environmentNotes"
+              name="environmentNotes"
+              rows="3"
+              placeholder="Detalhes adicionais, links, credenciais..."
+            ></textarea>
+          </div>
+          <div class="modal-actions">
+            <button type="button" class="ghost" data-modal-close>
+              Cancelar
+            </button>
+            <button type="submit" class="primary">Criar ambiente</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
-        <div class="card">
-          <h3>Ambientes</h3>
-          <button id="btnNovoAmbiente">+ Criar Ambiente</button>
-          <div id="ambientesList" class="grid"></div>
+    <!-- Modal Confirmação -->
+    <div class="modal" id="modalConfirm" role="dialog" aria-hidden="true">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Confirmação</h3>
+          <button type="button" class="icon-button" data-modal-close>
+            ×
+          </button>
         </div>
-      </section>
-
-      <!-- AMBIENTE DETALHE -->
-      <section id="secAmbiente" style="display: none">
-        <div class="topbar">
-          <button id="btnVoltarLoja">← Voltar</button>
-          <h2 id="ambienteTitulo"></h2>
+        <div class="modal-body">
+          <p id="confirmMessage"></p>
         </div>
-        <ul id="cenariosExecucao"></ul>
-      </section>
-    </main>
-
-    <footer>
-      <small>QA Dashboard · Firebase</small>
-    </footer>
+        <div class="modal-actions">
+          <button type="button" class="ghost" data-modal-close>Cancelar</button>
+          <button type="button" class="danger" id="confirmOk">Confirmar</button>
+        </div>
+      </div>
+    </div>
 
     <script type="module" src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -25,210 +25,697 @@ import {
   query,
   orderBy,
   serverTimestamp,
+  where,
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-let lojaSelecionada = null,
-  ambienteSelecionado = null;
+let lojaSelecionada = null;
+let ambienteSelecionado = null;
+let confirmHandler = null;
+let unsubscribeAmbientes = null;
+let unsubscribeAmbiente = null;
 
-// Helpers
 const el = (id) => document.getElementById(id);
+const showView = (id) => {
+  document.querySelectorAll(".view").forEach((section) => {
+    section.classList.toggle("is-visible", section.id === id);
+  });
+};
 
-// ---------- DASHBOARD ----------
+const normalizeUrl = (value) => {
+  if (!value) return "";
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "https://" || trimmed === "http://") return "";
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+};
+
+const formatUrlLabel = (url) => {
+  if (!url) return "";
+  try {
+    const normalized = normalizeUrl(url);
+    if (!normalized) return "";
+    const { hostname } = new URL(normalized);
+    return hostname.replace(/^www\./, "");
+  } catch (error) {
+    return url.replace(/^https?:\/\//i, "");
+  }
+};
+
+const statusLabels = {
+  pendente: "Pendente",
+  andamento: "Em andamento",
+  concluido: "Concluído",
+};
+
+const lojaTitulo = el("lojaTitulo");
+const lojaDescricao = el("lojaDescricao");
+const lojaSite = el("lojaSite");
+const lojaTotalCenarios = el("lojaTotalCenarios");
+const lojaTotalAmbientes = el("lojaTotalAmbientes");
+
+const scenarioForm = el("scenarioForm");
+const scenarioTitle = el("scenarioTitle");
+const scenarioCategory = el("scenarioCategory");
+const scenarioAutomation = el("scenarioAutomation");
+const scenarioCluster = el("scenarioCluster");
+const scenarioObs = el("scenarioObs");
+
+const storeForm = el("storeForm");
+const storeFormTitle = el("storeFormTitle");
+const storeFormSubmit = el("storeFormSubmit");
+const storeNameInput = el("storeName");
+const storeSiteInput = el("storeSite");
+const storeDescriptionInput = el("storeDescription");
+
+const environmentForm = el("environmentForm");
+const environmentStoreName = el("environmentStoreName");
+const environmentKindInput = el("environmentKind");
+const environmentTestTypeInput = el("environmentTestType");
+const environmentIdentifierInput = el("environmentIdentifier");
+const environmentNotesInput = el("environmentNotes");
+
+const confirmMessage = el("confirmMessage");
+const confirmOk = el("confirmOk");
+
+const ambienteTitulo = el("ambienteTitulo");
+const ambienteLoja = el("ambienteLoja");
+const ambienteKind = el("ambienteKind");
+const ambienteIdentifier = el("ambienteIdentifier");
+const ambienteTestType = el("ambienteTestType");
+const ambienteTotalCenarios = el("ambienteTotalCenarios");
+const ambienteNotes = el("ambienteNotes");
+const cenariosExecucao = el("cenariosExecucao");
+
+const abrirModal = (id) => {
+  const modal = el(id);
+  if (!modal) return;
+  modal.classList.add("is-open");
+  modal.setAttribute("aria-hidden", "false");
+  document.body.classList.add("modal-open");
+};
+
+const fecharModal = (target) => {
+  const modal = typeof target === "string" ? el(target) : target;
+  if (!modal) return;
+  modal.classList.remove("is-open");
+  modal.setAttribute("aria-hidden", "true");
+  if (!document.querySelector(".modal.is-open")) {
+    document.body.classList.remove("modal-open");
+  }
+};
+
+document.querySelectorAll(".modal").forEach((modal) => {
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) fecharModal(modal);
+  });
+});
+
+document.querySelectorAll("[data-modal-close]").forEach((button) => {
+  button.addEventListener("click", () => fecharModal(button.closest(".modal")));
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    document.querySelectorAll(".modal.is-open").forEach((modal) => fecharModal(modal));
+  }
+});
+
+const abrirConfirmacao = (mensagem, handler) => {
+  confirmMessage.textContent = mensagem;
+  confirmHandler = handler;
+  abrirModal("modalConfirm");
+};
+
+confirmOk.addEventListener("click", async () => {
+  if (typeof confirmHandler === "function") {
+    try {
+      await confirmHandler();
+    } catch (error) {
+      console.error("Erro ao executar confirmação:", error);
+    }
+  }
+  fecharModal("modalConfirm");
+  confirmHandler = null;
+});
+
+const renderLojaResumo = () => {
+  if (!lojaSelecionada) return;
+  lojaTitulo.textContent = lojaSelecionada.name || "Loja";
+
+  const descricao = (lojaSelecionada.description || "").trim();
+  lojaDescricao.textContent =
+    descricao || "Nenhuma descrição cadastrada. Utilize o botão Editar para adicionar um resumo.";
+
+  const siteNormalizado = normalizeUrl(lojaSelecionada.site || "");
+  if (siteNormalizado) {
+    lojaSite.textContent = formatUrlLabel(siteNormalizado);
+    lojaSite.href = siteNormalizado;
+    lojaSite.classList.remove("placeholder");
+  } else {
+    lojaSite.textContent = "Nenhum site cadastrado";
+    lojaSite.removeAttribute("href");
+    lojaSite.classList.add("placeholder");
+  }
+
+  const totalCenarios =
+    typeof lojaSelecionada.scenarioCount === "number"
+      ? lojaSelecionada.scenarioCount
+      : (lojaSelecionada.scenarios || []).length;
+  lojaTotalCenarios.textContent = totalCenarios;
+
+  lojaTotalAmbientes.textContent = lojaSelecionada.environmentCount ?? 0;
+};
+
+const atualizarLojaSelecionada = (partial = {}) => {
+  if (!lojaSelecionada) return;
+  const updatedSite =
+    partial.site !== undefined ? normalizeUrl(partial.site) : lojaSelecionada.site;
+  lojaSelecionada = {
+    ...lojaSelecionada,
+    ...partial,
+    site: updatedSite || "",
+  };
+  if (lojaSelecionada.description === undefined || lojaSelecionada.description === null) {
+    lojaSelecionada.description = "";
+  }
+  renderLojaResumo();
+};
+
 onSnapshot(
   query(collection(db, "stores"), orderBy("createdAt", "desc")),
   (snapshot) => {
     const dash = el("dashboardStores");
     dash.innerHTML = "";
+    let hasStores = false;
+
     snapshot.forEach((docSnap) => {
-      const d = docSnap.data(),
-        id = docSnap.id;
-      const card = document.createElement("div");
+      const data = docSnap.data();
+      const card = document.createElement("article");
       card.className = "store-card";
-      card.innerHTML = `<strong>${d.name}</strong><span>${
-        (d.scenarios || []).length
-      } cenários</span>`;
-      card.onclick = () => abrirLoja(id, d);
+
+      const header = document.createElement("div");
+      header.className = "store-card__header";
+
+      const title = document.createElement("strong");
+      title.className = "store-card__title";
+      title.textContent = data.name || "Loja";
+
+      const badge = document.createElement("span");
+      badge.className = "badge";
+      badge.textContent = `${(data.scenarios || []).length} cenários`;
+
+      header.append(title, badge);
+      card.appendChild(header);
+
+      const site = document.createElement("span");
+      site.className = "muted";
+      site.textContent = formatUrlLabel(data.site || "") || "Nenhum site cadastrado";
+      card.appendChild(site);
+
+      if (data.description) {
+        const desc = document.createElement("p");
+        desc.className = "scenario-note";
+        desc.textContent = data.description;
+        card.appendChild(desc);
+      }
+
+      card.addEventListener("click", () => abrirLoja(docSnap.id, data));
+
       dash.appendChild(card);
+      hasStores = true;
     });
+
+    if (!hasStores) {
+      const empty = document.createElement("div");
+      empty.className = "empty-state";
+      const title = document.createElement("h3");
+      title.textContent = "Nenhuma loja cadastrada";
+      const text = document.createElement("p");
+      text.className = "muted";
+      text.textContent = "Clique em \"+ Nova Loja\" para iniciar sua organização.";
+      empty.append(title, text);
+      dash.appendChild(empty);
+    }
   }
 );
 
-el("btnNovaLoja").onclick = async () => {
-  const nome = prompt("Nome da loja:");
-  if (!nome) return;
-  const site = prompt("Site:", "https://");
-  if (!site) return;
-  await addDoc(collection(db, "stores"), {
-    name: nome,
-    site,
-    scenarios: [],
-    createdAt: serverTimestamp(),
-  });
-};
+const abrirLoja = (id, data) => {
+  if (unsubscribeAmbiente) {
+    unsubscribeAmbiente();
+    unsubscribeAmbiente = null;
+  }
 
-// ---------- LOJA ----------
-function abrirLoja(id, data) {
-  lojaSelecionada = { id, ...data };
-  el("secDashboard").style.display = "none";
-  el("secLoja").style.display = "block";
-  el("lojaTitulo").textContent = data.name;
+  lojaSelecionada = {
+    id,
+    ...data,
+    description: data.description || "",
+    site: normalizeUrl(data.site || ""),
+    scenarios: Array.isArray(data.scenarios) ? data.scenarios : [],
+    scenarioCount: Array.isArray(data.scenarios) ? data.scenarios.length : 0,
+    environmentCount: 0,
+  };
+
+  renderLojaResumo();
+  showView("secLoja");
   loadCenariosTabela(id);
   loadAmbientes(id);
-}
-el("btnVoltarDashboard").onclick = () => {
-  el("secLoja").style.display = "none";
-  el("secDashboard").style.display = "block";
 };
 
-// editar/excluir loja
-el("btnEditarLoja").onclick = async () => {
-  if (!lojaSelecionada) return;
-  const nome = prompt("Novo nome:", lojaSelecionada.name);
-  const site = prompt("Novo site:", lojaSelecionada.site);
-  if (nome && site)
-    await updateDoc(doc(db, "stores", lojaSelecionada.id), {
-      name: nome,
-      site,
-    });
-};
-el("btnExcluirLoja").onclick = async () => {
-  if (!lojaSelecionada) return;
-  if (confirm("Excluir loja e ambientes?")) {
-    const envSnap = await getDocs(collection(db, "environments"));
-    envSnap.forEach(async (eDoc) => {
-      if (eDoc.data().storeId === lojaSelecionada.id)
-        await deleteDoc(doc(db, "environments", eDoc.id));
-    });
-    await deleteDoc(doc(db, "stores", lojaSelecionada.id));
-    el("secLoja").style.display = "none";
-    el("secDashboard").style.display = "block";
+el("btnVoltarDashboard").addEventListener("click", () => {
+  showView("secDashboard");
+  lojaSelecionada = null;
+  if (unsubscribeAmbientes) {
+    unsubscribeAmbientes();
+    unsubscribeAmbientes = null;
   }
-};
+  if (unsubscribeAmbiente) {
+    unsubscribeAmbiente();
+    unsubscribeAmbiente = null;
+  }
+});
 
-// ---------- CENÁRIOS ----------
-el("scenarioForm").addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const sc = {
-    title: el("scenarioTitle").value,
-    category: el("scenarioCategory").value,
-    automation: el("scenarioAutomation").value,
-    cluster: el("scenarioCluster").value,
-    obs: el("scenarioObs").value,
+el("btnVoltarLoja").addEventListener("click", () => {
+  showView("secLoja");
+  if (unsubscribeAmbiente) {
+    unsubscribeAmbiente();
+    unsubscribeAmbiente = null;
+  }
+  ambienteSelecionado = null;
+});
+
+el("btnNovaLoja").addEventListener("click", () => {
+  storeForm.reset();
+  storeForm.dataset.mode = "create";
+  storeFormTitle.textContent = "Nova loja";
+  storeFormSubmit.textContent = "Criar loja";
+  abrirModal("modalStore");
+});
+
+el("btnEditarLoja").addEventListener("click", () => {
+  if (!lojaSelecionada) return;
+  storeForm.reset();
+  storeForm.dataset.mode = "edit";
+  storeFormTitle.textContent = "Editar loja";
+  storeFormSubmit.textContent = "Salvar alterações";
+  storeNameInput.value = lojaSelecionada.name || "";
+  storeSiteInput.value = lojaSelecionada.site || "";
+  storeDescriptionInput.value = lojaSelecionada.description || "";
+  abrirModal("modalStore");
+});
+
+el("btnExcluirLoja").addEventListener("click", () => {
+  if (!lojaSelecionada) return;
+  abrirConfirmacao(
+    `Excluir a loja "${lojaSelecionada.name}" removerá todos os ambientes associados. Deseja continuar?`,
+    async () => {
+      const storeId = lojaSelecionada.id;
+      const envQuery = query(
+        collection(db, "environments"),
+        where("storeId", "==", storeId)
+      );
+      const envSnap = await getDocs(envQuery);
+      await Promise.all(envSnap.docs.map((d) => deleteDoc(d.ref)));
+      await deleteDoc(doc(db, "stores", storeId));
+      showView("secDashboard");
+      lojaSelecionada = null;
+      if (unsubscribeAmbientes) {
+        unsubscribeAmbientes();
+        unsubscribeAmbientes = null;
+      }
+    }
+  );
+});
+
+storeForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const mode = storeForm.dataset.mode || "create";
+  const name = storeNameInput.value.trim();
+  const site = normalizeUrl(storeSiteInput.value || "");
+  const description = storeDescriptionInput.value.trim();
+
+  if (!name) return;
+
+  const payload = {
+    name,
+    site,
+    description,
   };
+
+  try {
+    if (mode === "edit" && lojaSelecionada) {
+      await updateDoc(doc(db, "stores", lojaSelecionada.id), payload);
+      atualizarLojaSelecionada(payload);
+    } else {
+      await addDoc(collection(db, "stores"), {
+        ...payload,
+        scenarios: [],
+        createdAt: serverTimestamp(),
+      });
+    }
+    storeForm.reset();
+    fecharModal("modalStore");
+  } catch (error) {
+    console.error("Erro ao salvar loja:", error);
+  }
+});
+
+scenarioForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  if (!lojaSelecionada) return;
+
+  const scenario = {
+    title: scenarioTitle.value.trim(),
+    category: scenarioCategory.value.trim(),
+    automation: scenarioAutomation.value,
+    cluster: scenarioCluster.value,
+    obs: scenarioObs.value.trim(),
+  };
+
   const ref = doc(db, "stores", lojaSelecionada.id);
   const snap = await getDoc(ref);
-  let arr = snap.data().scenarios || [];
-  arr.push(sc);
+  const data = snap.data();
+  const arr = Array.isArray(data?.scenarios) ? [...data.scenarios] : [];
+  arr.push(scenario);
+
   await updateDoc(ref, { scenarios: arr });
-  e.target.reset();
+  scenarioForm.reset();
   loadCenariosTabela(lojaSelecionada.id);
 });
 
 async function loadCenariosTabela(id) {
   const ref = doc(db, "stores", id);
   const snap = await getDoc(ref);
+  if (!snap.exists()) return;
+
   const data = snap.data();
   const tab = el("cenariosTabela");
-  tab.innerHTML =
-    "<tr><th>Título</th><th>Categoria</th><th>Auto</th><th>Cluster</th><th>Obs</th><th></th></tr>";
-  (data.scenarios || []).forEach((sc, idx) => {
-    const tr = document.createElement("tr");
-    tr.innerHTML = `<td>${sc.title}</td><td>${sc.category}</td><td>${
-      sc.automation
-    }</td><td>${sc.cluster}</td><td>${sc.obs || ""}</td>`;
+  tab.innerHTML = `
+    <thead>
+      <tr>
+        <th>Título</th>
+        <th>Categoria</th>
+        <th>Automação</th>
+        <th>Cluster</th>
+        <th>Observações</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
+
+  const tbody = tab.querySelector("tbody");
+  const scenarios = Array.isArray(data.scenarios) ? data.scenarios : [];
+
+  if (!scenarios.length) {
+    const row = document.createElement("tr");
     const td = document.createElement("td");
-    const btn = document.createElement("button");
-    btn.textContent = "X";
-    btn.onclick = async () => {
-      let arr = data.scenarios;
-      arr.splice(idx, 1);
-      await updateDoc(ref, { scenarios: arr });
-      loadCenariosTabela(id);
-    };
-    td.appendChild(btn);
-    tr.appendChild(td);
-    tab.appendChild(tr);
-  });
+    td.colSpan = 6;
+    td.className = "empty";
+    td.textContent = "Nenhum cenário cadastrado até o momento.";
+    row.appendChild(td);
+    tbody.appendChild(row);
+  } else {
+    scenarios.forEach((sc, idx) => {
+      const row = document.createElement("tr");
+
+      const cellTitulo = document.createElement("td");
+      cellTitulo.textContent = sc.title || "-";
+
+      const cellCategoria = document.createElement("td");
+      cellCategoria.textContent = sc.category || "-";
+
+      const cellAuto = document.createElement("td");
+      cellAuto.textContent = sc.automation || "-";
+
+      const cellCluster = document.createElement("td");
+      cellCluster.textContent = sc.cluster || "-";
+
+      const cellObs = document.createElement("td");
+      cellObs.textContent = sc.obs || "";
+
+      const cellActions = document.createElement("td");
+      cellActions.className = "actions";
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "icon-danger";
+      btn.textContent = "Remover";
+      btn.addEventListener("click", async () => {
+        const newArr = [...scenarios];
+        newArr.splice(idx, 1);
+        await updateDoc(ref, { scenarios: newArr });
+        loadCenariosTabela(id);
+      });
+      cellActions.appendChild(btn);
+
+      row.append(cellTitulo, cellCategoria, cellAuto, cellCluster, cellObs, cellActions);
+      tbody.appendChild(row);
+    });
+  }
+
+  lojaSelecionada = {
+    ...lojaSelecionada,
+    ...data,
+    site: normalizeUrl(data.site || lojaSelecionada?.site || ""),
+    description: data.description || lojaSelecionada?.description || "",
+    scenarios,
+    scenarioCount: scenarios.length,
+  };
+  renderLojaResumo();
 }
 
-// ---------- AMBIENTES ----------
-el("btnNovoAmbiente").onclick = async () => {
-  const kind = prompt("Tipo de ambiente (WS/TM):", "WS");
-  const testType = prompt("Tipo de teste:", "regressivo");
-  const identifier = prompt("Identificador:", "ws-qa");
-  const sRef = doc(db, "stores", lojaSelecionada.id);
-  const snap = await getDoc(sRef);
-  const d = snap.data();
-  const scenarios = (d.scenarios || []).map((sc) => ({
-    ...sc,
-    status: "pendente",
-  }));
-  await addDoc(collection(db, "environments"), {
-    storeId: lojaSelecionada.id,
-    storeName: d.name,
-    kind,
-    testType,
-    identifier,
-    scenarios,
-    createdAt: serverTimestamp(),
-  });
-};
+el("btnNovoAmbiente").addEventListener("click", () => {
+  if (!lojaSelecionada) return;
+  environmentForm.reset();
+  environmentStoreName.textContent = lojaSelecionada.name;
+  abrirModal("modalEnvironment");
+});
+
+environmentForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  if (!lojaSelecionada) return;
+
+  const kind = environmentKindInput.value.trim();
+  const testType = environmentTestTypeInput.value;
+  const identifier = environmentIdentifierInput.value.trim();
+  const notes = environmentNotesInput.value.trim();
+
+  if (!kind || !identifier) return;
+
+  try {
+    const sRef = doc(db, "stores", lojaSelecionada.id);
+    const snap = await getDoc(sRef);
+    const data = snap.data() || lojaSelecionada;
+    const scenarios = Array.isArray(data.scenarios)
+      ? data.scenarios.map((sc) => ({ ...sc, status: "pendente" }))
+      : [];
+
+    await addDoc(collection(db, "environments"), {
+      storeId: lojaSelecionada.id,
+      storeName: data.name || lojaSelecionada.name,
+      kind,
+      testType,
+      identifier,
+      notes,
+      scenarios,
+      createdAt: serverTimestamp(),
+    });
+
+    environmentForm.reset();
+    fecharModal("modalEnvironment");
+  } catch (error) {
+    console.error("Erro ao criar ambiente:", error);
+  }
+});
 
 function loadAmbientes(storeId) {
-  onSnapshot(
+  if (unsubscribeAmbientes) {
+    unsubscribeAmbientes();
+  }
+
+  const list = el("ambientesList");
+
+  unsubscribeAmbientes = onSnapshot(
     query(collection(db, "environments"), orderBy("createdAt", "desc")),
     (snap) => {
-      const list = el("ambientesList");
       list.innerHTML = "";
+      let count = 0;
+
       snap.forEach((docSnap) => {
-        const env = docSnap.data(),
-          id = docSnap.id;
-        if (env.storeId === storeId) {
-          const card = document.createElement("div");
-          card.className = "store-card";
-          card.innerHTML = `<strong>${env.kind}</strong> - ${
-            env.testType
-          }<div>${(env.scenarios || []).length} cenários</div>`;
-          card.onclick = () => abrirAmbiente(env, id);
-          list.appendChild(card);
+        const env = docSnap.data();
+        if (env.storeId !== storeId) return;
+        count += 1;
+
+        const card = document.createElement("article");
+        card.className = "store-card";
+
+        const header = document.createElement("div");
+        header.className = "store-card__header";
+        const title = document.createElement("strong");
+        title.className = "store-card__title";
+        title.textContent = env.kind || "Ambiente";
+        const badge = document.createElement("span");
+        badge.className = "badge";
+        badge.textContent = `${(env.scenarios || []).length} cenários`;
+        header.append(title, badge);
+        card.appendChild(header);
+
+        const meta = document.createElement("span");
+        meta.className = "muted";
+        const metaParts = [];
+        if (env.testType) metaParts.push(env.testType);
+        if (env.identifier) metaParts.push(env.identifier);
+        meta.textContent = metaParts.join(" • ") || "Detalhes não informados";
+        card.appendChild(meta);
+
+        if (env.notes) {
+          const notes = document.createElement("p");
+          notes.className = "scenario-note";
+          notes.textContent = env.notes;
+          card.appendChild(notes);
         }
+
+        card.addEventListener("click", () => abrirAmbiente(env, docSnap.id));
+        list.appendChild(card);
       });
+
+      if (count === 0) {
+        const empty = document.createElement("div");
+        empty.className = "empty-state";
+        const title = document.createElement("h3");
+        title.textContent = "Nenhum ambiente criado";
+        const text = document.createElement("p");
+        text.className = "muted";
+        text.textContent = "Crie o primeiro ambiente para acompanhar execuções.";
+        const action = document.createElement("button");
+        action.className = "ghost";
+        action.textContent = "Criar ambiente";
+        action.addEventListener("click", () => el("btnNovoAmbiente").click());
+        empty.append(title, text, action);
+        list.appendChild(empty);
+      }
+
+      atualizarLojaSelecionada({ environmentCount: count });
     }
   );
 }
 
-// ---------- AMBIENTE DETALHE ----------
 function abrirAmbiente(env, id) {
+  showView("secAmbiente");
+
+  if (unsubscribeAmbiente) {
+    unsubscribeAmbiente();
+  }
+
   ambienteSelecionado = { id, ...env };
-  el("secLoja").style.display = "none";
-  el("secAmbiente").style.display = "block";
-  el("ambienteTitulo").textContent = `${env.kind} - ${env.testType} (${
-    env.identifier || ""
-  })`;
-  const ul = el("cenariosExecucao");
-  ul.innerHTML = "";
-  (env.scenarios || []).forEach((sc, idx) => {
-    const li = document.createElement("li");
-    li.innerHTML = `${sc.title} (${sc.category})`;
-    const select = document.createElement("select");
-    select.className = "status";
-    ["pendente", "andamento", "concluido"].forEach((opt) => {
-      const o = new Option(opt, opt, opt === sc.status, opt === sc.status);
-      select.appendChild(o);
-    });
-    select.onchange = async () => {
-      let newSc = [...env.scenarios];
-      newSc[idx].status = select.value;
-      await updateDoc(doc(db, "environments", id), { scenarios: newSc });
-    };
-    li.appendChild(select);
-    ul.appendChild(li);
+  renderAmbiente();
+
+  unsubscribeAmbiente = onSnapshot(doc(db, "environments", id), (snap) => {
+    if (!snap.exists()) {
+      ambienteSelecionado = null;
+      if (unsubscribeAmbiente) {
+        unsubscribeAmbiente();
+        unsubscribeAmbiente = null;
+      }
+      showView("secLoja");
+      return;
+    }
+    ambienteSelecionado = { id: snap.id, ...snap.data() };
+    renderAmbiente();
   });
 }
-el("btnVoltarLoja").onclick = () => {
-  el("secAmbiente").style.display = "none";
-  el("secLoja").style.display = "block";
-};
+
+function renderAmbiente() {
+  if (!ambienteSelecionado) return;
+
+  const env = ambienteSelecionado;
+  const headerParts = [env.kind, env.testType].filter(Boolean).join(" · ");
+  const suffix = env.identifier ? ` — ${env.identifier}` : "";
+  ambienteTitulo.textContent = `${headerParts || "Ambiente"}${suffix}`;
+
+  ambienteLoja.textContent = env.storeName || lojaSelecionada?.name || "-";
+  ambienteKind.textContent = env.kind || "-";
+  ambienteIdentifier.textContent = env.identifier || "—";
+  ambienteTestType.textContent = env.testType || "—";
+  ambienteTotalCenarios.textContent = env.scenarios?.length || 0;
+  ambienteNotes.textContent = env.notes || "Nenhuma observação registrada para este ambiente.";
+  ambienteNotes.classList.toggle("muted", !env.notes);
+
+  cenariosExecucao.innerHTML = "";
+  const scenarios = Array.isArray(env.scenarios) ? env.scenarios : [];
+
+  if (!scenarios.length) {
+    const empty = document.createElement("li");
+    empty.className = "empty-state";
+    const title = document.createElement("h3");
+    title.textContent = "Sem cenários neste ambiente";
+    const text = document.createElement("p");
+    text.className = "muted";
+    text.textContent = "Adicione cenários na loja para que apareçam aqui.";
+    empty.append(title, text);
+    cenariosExecucao.appendChild(empty);
+    return;
+  }
+
+  scenarios.forEach((sc, idx) => {
+    const item = document.createElement("li");
+    item.className = "scenario-row";
+
+    const info = document.createElement("div");
+    info.className = "scenario-info";
+
+    const title = document.createElement("strong");
+    title.textContent = sc.title || "Cenário";
+
+    const meta = document.createElement("span");
+    meta.className = "scenario-meta";
+    const details = [sc.category, sc.cluster, sc.automation].filter(Boolean).join(" • ");
+    meta.textContent = details || "Detalhes não informados";
+
+    info.append(title, meta);
+
+    if (sc.obs) {
+      const note = document.createElement("span");
+      note.className = "scenario-note";
+      note.textContent = sc.obs;
+      info.appendChild(note);
+    }
+
+    const select = document.createElement("select");
+    const statusAtual = sc.status || "pendente";
+    select.className = `status status--${statusAtual}`;
+
+    ["pendente", "andamento", "concluido"].forEach((status) => {
+      const option = document.createElement("option");
+      option.value = status;
+      option.textContent = statusLabels[status];
+      option.selected = status === statusAtual;
+      select.appendChild(option);
+    });
+
+    select.addEventListener("change", async () => {
+      const novoStatus = select.value;
+      select.className = `status status--${novoStatus}`;
+
+      const envId = ambienteSelecionado?.id;
+      if (!envId) return;
+
+      const atualizados = (ambienteSelecionado.scenarios || []).map((item, index) =>
+        index === idx ? { ...item, status: novoStatus } : item
+      );
+
+      select.disabled = true;
+      try {
+        await updateDoc(doc(db, "environments", envId), { scenarios: atualizados });
+      } catch (error) {
+        console.error("Erro ao atualizar status:", error);
+      } finally {
+        select.disabled = false;
+      }
+    });
+
+    item.append(info, select);
+    cenariosExecucao.appendChild(item);
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,115 +1,643 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --bg-alt: #0b1220;
+  --surface: rgba(17, 24, 39, 0.88);
+  --surface-alt: rgba(22, 33, 62, 0.92);
+  --border: rgba(148, 163, 184, 0.16);
+  --border-strong: rgba(148, 163, 184, 0.28);
+  --primary: linear-gradient(135deg, #2563eb, #7c3aed);
+  --primary-flat: #2563eb;
+  --primary-hover: #1d4ed8;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
 * {
   box-sizing: border-box;
-  font-family: system-ui, Roboto, sans-serif;
 }
+
 body {
   margin: 0;
-  background: #0f172a;
-  color: #e2e8f0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 10%, #1d4ed8 0%, rgba(37, 99, 235, 0) 55%),
+    radial-gradient(circle at 80% 0%, rgba(236, 72, 153, 0.55) 0%, rgba(236, 72, 153, 0) 45%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
 }
-header {
-  padding: 16px 20px;
-  border-bottom: 1px solid #334155;
-  background: #111827;
+
+body.modal-open {
+  overflow: hidden;
 }
-h1 {
+
+a {
+  color: inherit;
+}
+
+a.link {
+  color: var(--text);
+  text-decoration: none;
+  position: relative;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+a.link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background: rgba(148, 163, 184, 0.4);
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform 0.2s ease;
+}
+
+a.link:hover::after {
+  transform: scaleX(1);
+}
+
+a.link.placeholder {
+  pointer-events: none;
+  color: var(--muted);
+}
+
+a.link.placeholder::after {
+  display: none;
+}
+
+.app-shell {
+  width: min(1180px, 100%);
+  padding: 32px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 28px;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 25px 40px rgba(15, 23, 42, 0.35);
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.brand-icon {
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  font-size: 26px;
+  border-radius: 14px;
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.brand-text h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: 0.01em;
+}
+
+.brand-text p {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.section-heading h2 {
+  margin: 0 0 6px;
+  font-size: 1.5rem;
+}
+
+.section-heading .muted {
   margin: 0;
 }
-main {
-  max-width: 1100px;
-  margin: 20px auto;
-  padding: 0 16px;
-}
+
 footer {
   text-align: center;
-  padding: 20px;
-  color: #94a3b8;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  background: var(--surface-alt);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    border 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  border: 1px solid transparent;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.32);
+}
+
+button.primary:hover:not(:disabled) {
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.42);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+button.ghost:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+button.danger {
+  background: var(--danger);
+  color: #fff;
+  border: 1px solid transparent;
+}
+
+button.danger:hover:not(:disabled) {
+  background: var(--danger-hover);
+}
+
+.icon-button {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.icon-button:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.view {
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.view.is-visible {
+  display: flex;
 }
 
 .topbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-}
-button {
-  background: #2563eb;
-  border: none;
-  padding: 8px 14px;
-  border-radius: 6px;
-  color: white;
-  cursor: pointer;
-}
-button:hover {
-  background: #1d4ed8;
-}
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 16px;
 }
-.grid-form {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 8px;
-  margin: 12px 0;
+
+.topbar h2 {
+  margin: 0;
 }
 
 .card {
-  background: #111827;
-  border: 1px solid #334155;
-  border-radius: 10px;
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.store-card {
-  padding: 16px;
-  border-radius: 10px;
-  background: #1e293b;
-  cursor: pointer;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 20px;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.28);
 }
+
+.card--overview {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.24), rgba(124, 58, 237, 0.24));
+  border: 1px solid rgba(59, 130, 246, 0.32);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.card-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.card-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.label {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+  margin-bottom: 4px;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.store-card {
+  padding: 22px;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
 .store-card:hover {
-  background: #334155;
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.5);
+  box-shadow: 0 28px 45px rgba(15, 23, 42, 0.42);
 }
+
+.store-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.store-card__title {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
 .badge {
-  background: #334155;
-  padding: 2px 6px;
-  border-radius: 6px;
-  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.tag {
+  display: inline-flex;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(191, 219, 254, 0.95);
+  font-size: 0.75rem;
+}
+
+.grid-form {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field--wide {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--text);
+  font: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.24);
+}
+
+select {
+  appearance: none;
+}
+
+.table-wrapper {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 12px;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
 }
-td,
-th {
-  border: 1px solid #334155;
-  padding: 8px;
+
+thead {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+th,
+td {
+  padding: 14px 18px;
   text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
 }
-th {
-  background: #1e293b;
+
+tbody tr:hover {
+  background: rgba(148, 163, 184, 0.05);
 }
+
+td.actions {
+  width: 60px;
+}
+
+td.empty {
+  text-align: center;
+  padding: 26px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+button.icon-danger {
+  background: rgba(239, 68, 68, 0.18);
+  color: rgba(254, 226, 226, 0.9);
+  border-radius: var(--radius-md);
+  padding: 8px;
+  border: none;
+}
+
+button.icon-danger:hover {
+  background: rgba(239, 68, 68, 0.28);
+}
+
 ul {
   list-style: none;
+  margin: 0;
   padding: 0;
 }
-ul li {
-  padding: 8px;
-  border-bottom: 1px solid #334155;
+
+.scenario-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.scenario-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.scenario-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scenario-info strong {
+  font-size: 1rem;
+}
+
+.scenario-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.scenario-note {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.85rem;
+}
+
+.status {
+  min-width: 170px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+}
+
+.status--pendente {
+  background: rgba(234, 179, 8, 0.12);
+  border-color: rgba(234, 179, 8, 0.38);
+  color: #facc15;
+}
+
+.status--andamento {
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(59, 130, 246, 0.42);
+  color: #60a5fa;
+}
+
+.status--concluido {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.42);
+  color: #4ade80;
+}
+
+.empty-state {
+  padding: 40px 28px;
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.68);
+  text-align: center;
+  display: grid;
+  gap: 12px;
+  place-items: center;
+}
+
+.empty-state h3 {
+  margin: 0;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(8, 12, 24, 0.8);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  padding: 32px 16px;
+  z-index: 1000;
+}
+
+.modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  width: min(520px, 100%);
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 28px 50px rgba(8, 12, 24, 0.6);
+  transform: translateY(16px) scale(0.98);
+  transition: transform 0.25s ease;
+  overflow: hidden;
+}
+
+.modal.is-open .modal-content {
+  transform: translateY(0) scale(1);
+}
+
+.modal-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 20px 24px 0;
+  gap: 16px;
 }
-select.status {
-  background: #1e293b;
-  color: white;
-  border: none;
-  padding: 4px;
-  border-radius: 6px;
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 16px 24px 24px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    padding: 24px 16px 36px;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .card {
+    padding: 20px;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .card-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .scenario-row {
+    flex-direction: column;
+  }
+
+  .status {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .brand {
+    align-items: flex-start;
+  }
+
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  table {
+    font-size: 0.9rem;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the QA dashboard layout with a modern dark UI and responsive components
- replace browser prompts with reusable modal forms for stores, environments and confirmations
- enrich store, scenario and environment management with better summaries and real-time status controls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cde3390c908327b1c7b0fed5e96c2b