### PR TITLE
Add scenario import/export and filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,14 @@
                   <option value="Ambos">Ambos</option>
                 </select>
               </div>
+              <div class="field">
+                <label for="scenarioStage">Fase do teste</label>
+                <select id="scenarioStage">
+                  <option value="pre-deploy">Pré-deploy</option>
+                  <option value="pos-deploy">Pós-deploy</option>
+                  <option value="regressivo">Regressivo</option>
+                </select>
+              </div>
               <div class="field field--wide">
                 <label for="scenarioObs">Observações</label>
                 <textarea
@@ -222,6 +230,39 @@
                 <button type="submit" class="primary">Adicionar cenário</button>
               </div>
             </form>
+
+            <div class="scenario-toolbar">
+              <div class="scenario-toolbar__filters">
+                <label for="scenarioCategoryFilter">Filtrar por categoria</label>
+                <select id="scenarioCategoryFilter">
+                  <option value="all">Todas as categorias</option>
+                </select>
+              </div>
+              <div class="scenario-toolbar__actions">
+                <div class="scenario-toolbar__group">
+                  <button type="button" id="btnImportCsv" class="ghost">
+                    Importar CSV
+                  </button>
+                  <button type="button" id="btnImportJson" class="ghost">
+                    Importar JSON
+                  </button>
+                </div>
+                <div class="scenario-toolbar__group">
+                  <button type="button" id="btnExportMarkdown" class="ghost">
+                    Exportar Markdown
+                  </button>
+                  <button type="button" id="btnExportPdf" class="ghost">
+                    Exportar PDF
+                  </button>
+                </div>
+              </div>
+            </div>
+            <input
+              type="file"
+              id="scenarioImportInput"
+              accept=".csv,application/json,.json"
+              style="display: none"
+            />
 
             <table id="cenariosTabela"></table>
           </div>

--- a/style.css
+++ b/style.css
@@ -646,6 +646,10 @@ table {
   overflow: hidden;
 }
 
+#cenariosTabela {
+  margin-top: 16px;
+}
+
 thead {
   background: var(--table-header);
 }
@@ -659,6 +663,44 @@ td {
 
 tbody tr:hover {
   background: var(--table-hover);
+}
+
+.scenario-toolbar {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.scenario-toolbar__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scenario-toolbar__filters label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.scenario-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.scenario-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.scenario-toolbar select {
+  min-width: 200px;
 }
 
 td.actions {
@@ -858,6 +900,15 @@ ul {
 
   .status {
     width: 100%;
+  }
+
+  .scenario-toolbar {
+    align-items: stretch;
+  }
+
+  .scenario-toolbar__actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow importing store scenarios from CSV or JSON files and export the list to Markdown or PDF
- add category filtering and management toolbar for store scenarios
- support selecting the execution stage (pré/pós/regressivo) and surface it throughout the app

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdf490d56c8327b6f60f574e4c297a