### PR TITLE
Add curated scenario packages for different test stages

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,14 +210,6 @@
                   <option value="Ambos">Ambos</option>
                 </select>
               </div>
-              <div class="field">
-                <label for="scenarioStage">Fase do teste</label>
-                <select id="scenarioStage">
-                  <option value="pre-deploy">Pré-deploy</option>
-                  <option value="pos-deploy">Pós-deploy</option>
-                  <option value="regressivo">Regressivo</option>
-                </select>
-              </div>
               <div class="field field--wide">
                 <label for="scenarioObs">Observações</label>
                 <textarea
@@ -265,6 +257,17 @@
             />
 
             <table id="cenariosTabela"></table>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3>Pacotes de cenários de teste</h3>
+            </div>
+            <p class="muted">
+              Utilize coleções prontas conforme o estágio do projeto para acelerar
+              o planejamento de testes e padronizar entregas.
+            </p>
+            <div id="scenarioPackages" class="package-grid"></div>
           </div>
 
           <div class="card">

--- a/style.css
+++ b/style.css
@@ -714,6 +714,88 @@ td.empty {
   font-size: 0.95rem;
 }
 
+.package-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.scenario-package {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+}
+
+.scenario-package h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.scenario-package__moment {
+  font-size: 0.95rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.scenario-package__moment strong {
+  color: var(--text);
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.scenario-package__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scenario-package__section-title {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--label);
+}
+
+.scenario-package__list {
+  list-style: disc;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+}
+
+.scenario-package__examples li strong {
+  display: block;
+  font-weight: 600;
+}
+
+.scenario-package__meta {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.scenario-package__note {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.scenario-package__actions {
+  margin-top: auto;
+}
+
+.scenario-package__actions button {
+  width: 100%;
+}
+
 button.icon-danger {
   background: var(--danger-soft);
   color: var(--danger-text);


### PR DESCRIPTION
## Summary
- add a dedicated card that highlights test scenario packages per stage
- render predefined packages with objectives, moments, and example scenarios that can be added to the current store
- style the package grid and avoid duplicating scenarios when applying a package

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdf9323af48327b5f27cdef8da206e