### PR TITLE
Add JSON import, PDF export fix, and coverage dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,20 @@
               </p>
             </div>
           </div>
+          <div class="dashboard-analytics">
+            <article class="card card--analytics" aria-live="polite">
+              <div class="card-header">
+                <div>
+                  <p class="card-subtitle">Cobertura de testes</p>
+                  <h3>Comparativo entre lojas</h3>
+                </div>
+                <span id="dashboardCoverageSummary" class="badge"
+                  >Média geral: 0%</span
+                >
+              </div>
+              <div id="dashboardCoverageList" class="coverage-list"></div>
+            </article>
+          </div>
           <div id="dashboardStores" class="grid"></div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -529,6 +529,139 @@ button.danger:hover:not(:disabled) {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
+.dashboard-analytics {
+  display: grid;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.card--analytics {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+}
+
+.coverage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.coverage-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.coverage-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.coverage-row__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.coverage-row__name {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.coverage-row__value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.coverage-progress {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+  display: flex;
+}
+
+.coverage-progress__bar {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.coverage-progress__bar.is-done {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(16, 185, 129, 0.9));
+}
+
+.coverage-progress__bar.is-running {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.85), rgba(245, 158, 11, 0.85));
+}
+
+.coverage-progress__bar.is-pending {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.6), rgba(100, 116, 139, 0.6));
+}
+
+.coverage-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.coverage-row__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.coverage-row__note {
+  font-size: 0.85rem;
+}
+
+.coverage-row__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  display: inline-flex;
+}
+
+.coverage-row__dot.is-done {
+  background: #22c55e;
+}
+
+.coverage-row__dot.is-running {
+  background: #facc15;
+}
+
+.coverage-row__dot.is-pending {
+  background: #64748b;
+}
+
+.coverage-row__env {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.14);
+  color: rgba(191, 219, 254, 0.95);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+body[data-theme="light"] .coverage-row__env {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.coverage-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .store-card {
   padding: 22px;
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- add a dashboard analytics card that compares store test coverage with progress bars and averages
- harden scenario import to support JSON files (BOM, nested keys) and reuse the sanitization pipeline
- fix PDF export by loading the jsPDF ESM build with a UMD fallback and sharing date helpers for coverage info

## Testing
- not run (web app change)

------
https://chatgpt.com/codex/tasks/task_e_68ce87a85cb0832781c4a7346e1249ca