### PR TITLE
Fix PDF export and add JSON export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,9 @@
                   <button type="button" id="btnExportMarkdown" class="ghost">
                     Exportar Markdown
                   </button>
+                  <button type="button" id="btnExportJson" class="ghost">
+                    Exportar JSON
+                  </button>
                   <button type="button" id="btnExportPdf" class="ghost">
                     Exportar PDF
                   </button>


### PR DESCRIPTION
## Summary
- switch the PDF export to load the ESM build of jsPDF and reapply the header when adding pages
- centralize scenario export preparation so Markdown/PDF exports use consistent, sanitized data
- add a JSON export action in the UI and generate a structured payload with store metadata

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce999b69408327a38b5269018efbfc