### PR TITLE
feat: improve ambiente scenario management

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,18 @@
                     Exportar PDF
                   </button>
                 </div>
+                <div class="scenario-toolbar__group">
+                  <button
+                    type="button"
+                    id="btnToggleStoreScenarioTable"
+                    class="ghost"
+                    data-expanded-label="Minimizar tabela"
+                    data-collapsed-label="Expandir tabela"
+                    aria-expanded="true"
+                  >
+                    Minimizar tabela
+                  </button>
+                </div>
               </div>
             </div>
             <input
@@ -259,7 +271,9 @@
               style="display: none"
             />
 
-            <table id="cenariosTabela"></table>
+            <div class="table-wrapper" id="storeScenarioTableWrapper">
+              <table id="cenariosTabela"></table>
+            </div>
           </div>
 
           <div class="card">
@@ -320,8 +334,40 @@
                   <option value="all">Todas as categorias</option>
                 </select>
               </div>
+              <div class="scenario-toolbar__actions">
+                <div class="scenario-toolbar__group">
+                  <button
+                    type="button"
+                    id="btnAmbienteExportMarkdown"
+                    class="ghost"
+                  >
+                    Exportar Markdown
+                  </button>
+                  <button
+                    type="button"
+                    id="btnAmbienteExportPdf"
+                    class="ghost"
+                  >
+                    Exportar PDF
+                  </button>
+                </div>
+                <div class="scenario-toolbar__group">
+                  <button
+                    type="button"
+                    id="btnToggleAmbienteScenarioTable"
+                    class="ghost"
+                    data-expanded-label="Minimizar tabela"
+                    data-collapsed-label="Expandir tabela"
+                    aria-expanded="true"
+                  >
+                    Minimizar tabela
+                  </button>
+                </div>
+              </div>
             </div>
-            <ul id="cenariosExecucao" class="scenario-list"></ul>
+            <div class="table-wrapper" id="ambienteScenarioTableWrapper">
+              <table id="ambienteCenariosTabela"></table>
+            </div>
           </div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -101,6 +101,10 @@ body.modal-open {
   display: none !important;
 }
 
+.is-collapsed {
+  display: none !important;
+}
+
 a {
   color: inherit;
 }
@@ -635,6 +639,7 @@ select {
 .table-wrapper {
   border-radius: var(--radius-lg);
   overflow: hidden;
+  margin-top: 16px;
 }
 
 table {
@@ -644,10 +649,6 @@ table {
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   overflow: hidden;
-}
-
-#cenariosTabela {
-  margin-top: 16px;
 }
 
 thead {
@@ -794,6 +795,10 @@ ul {
   background: rgba(34, 197, 94, 0.16);
   border-color: rgba(34, 197, 94, 0.42);
   color: #4ade80;
+}
+
+.scenario-stage {
+  min-width: 160px;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- add collapse controls and wrappers to the loja and ambiente scenario tables
- render ambiente scenarios in a table with editable status/type metadata
- export ambiente scenarios to Markdown/PDF and set default stage when creating environments

## Testing
- Not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68ce9fb5ec6c832791532ac0febd5484